### PR TITLE
Handle transient 403 Forbidden responses with retry logic

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "folioclient"
-version = "1.0.7"
+version = "1.0.8"
 description = "An API wrapper over the FOLIO LSP API Suite (Formerly OKAPI)."
 authors = [
     { name = "Theodor Tolstoy", email = "github.teddes@tolstoy.se" },

--- a/src/folioclient/_httpx.py
+++ b/src/folioclient/_httpx.py
@@ -116,11 +116,7 @@ class FolioAuth(httpx.Auth):
             logger.debug("Received unexpected 403 Forbidden. Will retry request once.")
             retry_response = yield request
             if retry_response.status_code == HTTPStatus.FORBIDDEN:
-                raise httpx.HTTPStatusError(
-                    "Received 403 Forbidden. Check if the user has the necessary permissions.",
-                    request=request,
-                    response=retry_response,
-                )
+                retry_response.raise_for_status()  # Raise 403 if still forbidden after retry
 
     async def async_auth_flow(
         self, request: httpx.Request
@@ -158,15 +154,12 @@ class FolioAuth(httpx.Auth):
                     request=request,
                     response=retry_response,
                 )
+
         if response.status_code == HTTPStatus.FORBIDDEN:
             logger.debug("Received unexpected 403 Forbidden. Will retry request once.")
             retry_response = yield request
             if retry_response.status_code == HTTPStatus.FORBIDDEN:
-                raise httpx.HTTPStatusError(
-                    "Received 403 Forbidden. Check if the user has the necessary permissions.",
-                    request=request,
-                    response=retry_response,
-                )
+                retry_response.raise_for_status()  # Raise 403 if still forbidden after retry
 
     def _do_sync_auth(self) -> _Token:
         """Synchronous authentication with the FOLIO system."""

--- a/src/folioclient/_httpx.py
+++ b/src/folioclient/_httpx.py
@@ -112,6 +112,16 @@ class FolioAuth(httpx.Auth):
                     response=retry_response,
                 )
 
+        if response.status_code == HTTPStatus.FORBIDDEN:
+            logger.debug("Received unexpected 403 Forbidden. Will retry request once.")
+            retry_response = yield request
+            if retry_response.status_code == HTTPStatus.FORBIDDEN:
+                raise httpx.HTTPStatusError(
+                    "Received 403 Forbidden. Check if the user has the necessary permissions.",
+                    request=request,
+                    response=retry_response,
+                )
+
     async def async_auth_flow(
         self, request: httpx.Request
     ) -> "AsyncGenerator[httpx.Request, httpx.Response]":
@@ -145,6 +155,15 @@ class FolioAuth(httpx.Auth):
                 raise httpx.HTTPStatusError(
                     "Authentication failed after token refresh."
                     " Check credentials and authorization.",
+                    request=request,
+                    response=retry_response,
+                )
+        if response.status_code == HTTPStatus.FORBIDDEN:
+            logger.debug("Received unexpected 403 Forbidden. Will retry request once.")
+            retry_response = yield request
+            if retry_response.status_code == HTTPStatus.FORBIDDEN:
+                raise httpx.HTTPStatusError(
+                    "Received 403 Forbidden. Check if the user has the necessary permissions.",
                     request=request,
                     response=retry_response,
                 )

--- a/tests/test_httpx.py
+++ b/tests/test_httpx.py
@@ -424,3 +424,98 @@ def test_folio_refresh_token_refreshes_when_expired(monkeypatch):
         now = datetime.now(tz=timezone.utc)
         fa._token = FolioAuth._Token(auth_token="expired", refresh_token="old", expires_at=now - timedelta(seconds=10), refresh_token_expires_at=None, cookies=None)
         assert fa.folio_refresh_token == "newr"
+
+
+def test_sync_auth_flow_403_retry_success(monkeypatch):
+    """403 Forbidden on first attempt should retry, and succeed if retry returns 200."""
+    params = make_params()
+    auth_cookies = {"folioAccessToken": "auth-t", "folioRefreshToken": "auth-r"}
+    auth_resp = DummyResponse(cookies=auth_cookies, json_data={})
+
+    def fake_client(*args, **kwargs):
+        return DummyClient(auth_resp)
+
+    with httpx_client_patcher(fake_client):
+        fa = FolioAuth(params)
+        req = httpx.Request("GET", "https//folio/resource")
+        gen = fa.sync_auth_flow(req)
+        next(gen)
+        # First response is 403 — triggers retry
+        yielded = gen.send(DummyResponse(status_code=403))
+        assert yielded is req
+        # Retry succeeds with 200
+        with pytest.raises(StopIteration):
+            gen.send(DummyResponse(status_code=200))
+
+
+def test_sync_auth_flow_403_retry_still_forbidden(monkeypatch):
+    """403 on both attempts should raise HTTPStatusError."""
+    params = make_params()
+    auth_cookies = {"folioAccessToken": "auth-t", "folioRefreshToken": "auth-r"}
+    auth_resp = DummyResponse(cookies=auth_cookies, json_data={})
+
+    def fake_client(*args, **kwargs):
+        return DummyClient(auth_resp)
+
+    with httpx_client_patcher(fake_client):
+        fa = FolioAuth(params)
+        req = httpx.Request("GET", "https//folio/resource")
+        gen = fa.sync_auth_flow(req)
+        next(gen)
+        # First response is 403 — triggers retry
+        gen.send(DummyResponse(status_code=403))
+        # Retry also returns 403 — should raise
+        with pytest.raises(httpx.HTTPStatusError):
+            gen.send(DummyResponse(status_code=403))
+
+
+@pytest.mark.asyncio
+async def test_async_auth_flow_403_retry_success(monkeypatch):
+    """Async: 403 Forbidden on first attempt should retry, and succeed if retry returns 200."""
+    params = make_params()
+    auth_cookies = {"folioAccessToken": "auth-t", "folioRefreshToken": "auth-r"}
+    auth_resp = DummyResponse(cookies=auth_cookies, json_data={})
+
+    def fake_client(*args, **kwargs):
+        return DummyClient(auth_resp)
+
+    def fake_async_client(*args, **kwargs):
+        return DummyAsyncClient(auth_resp)
+
+    with httpx_client_patcher(fake_client, fake_async_client):
+        fa = FolioAuth(params)
+        req = httpx.Request("GET", "https//folio/async-resource")
+        agen = fa.async_auth_flow(req)
+        first = await agen.__anext__()
+        assert first is req
+        # First response is 403 — triggers retry
+        yielded = await agen.asend(DummyResponse(status_code=403))
+        assert yielded is req
+        # Retry succeeds with 200
+        with pytest.raises(StopAsyncIteration):
+            await agen.asend(DummyResponse(status_code=200))
+
+
+@pytest.mark.asyncio
+async def test_async_auth_flow_403_retry_still_forbidden(monkeypatch):
+    """Async: 403 on both attempts should raise HTTPStatusError."""
+    params = make_params()
+    auth_cookies = {"folioAccessToken": "auth-t", "folioRefreshToken": "auth-r"}
+    auth_resp = DummyResponse(cookies=auth_cookies, json_data={})
+
+    def fake_client(*args, **kwargs):
+        return DummyClient(auth_resp)
+
+    def fake_async_client(*args, **kwargs):
+        return DummyAsyncClient(auth_resp)
+
+    with httpx_client_patcher(fake_client, fake_async_client):
+        fa = FolioAuth(params)
+        req = httpx.Request("GET", "https//folio/async-resource")
+        agen = fa.async_auth_flow(req)
+        await agen.__anext__()
+        # First response is 403 — triggers retry
+        await agen.asend(DummyResponse(status_code=403))
+        # Retry also returns 403 — should raise
+        with pytest.raises(httpx.HTTPStatusError):
+            await agen.asend(DummyResponse(status_code=403))


### PR DESCRIPTION
Implement retry logic for handling transient 403 Forbidden responses in the FolioAuth class. Add tests to ensure correct behavior for both synchronous and asynchronous flows.