### PR TITLE
Read response in auth before raising error for 403 exceptions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "folioclient"
-version = "1.0.9"
+version = "1.0.10"
 description = "An API wrapper over the FOLIO LSP API Suite (Formerly OKAPI)."
 authors = [
     { name = "Theodor Tolstoy", email = "github.teddes@tolstoy.se" },

--- a/src/folioclient/_httpx.py
+++ b/src/folioclient/_httpx.py
@@ -116,6 +116,8 @@ class FolioAuth(httpx.Auth):
             logger.debug("Received unexpected 403 Forbidden. Will retry request once.")
             retry_response = yield request
             if retry_response.status_code == HTTPStatus.FORBIDDEN:
+                # Ensure response body is available to callers inspecting exception.response.text
+                retry_response.read()
                 retry_response.raise_for_status()  # Raise 403 if still forbidden after retry
 
     async def async_auth_flow(
@@ -159,6 +161,8 @@ class FolioAuth(httpx.Auth):
             logger.debug("Received unexpected 403 Forbidden. Will retry request once.")
             retry_response = yield request
             if retry_response.status_code == HTTPStatus.FORBIDDEN:
+                # Ensure response body is available to callers inspecting exception.response.text
+                await retry_response.aread()
                 retry_response.raise_for_status()  # Raise 403 if still forbidden after retry
 
     def _do_sync_auth(self) -> _Token:

--- a/tests/test_httpx.py
+++ b/tests/test_httpx.py
@@ -29,6 +29,12 @@ class DummyResponse:
     def json(self):
         return self._json
 
+    def read(self):
+        return b""
+
+    async def aread(self):
+        return b""
+
     def raise_for_status(self):
         if not (200 <= self.status_code < 300):
             raise httpx.HTTPStatusError("status", request=None, response=self)


### PR DESCRIPTION
The recent change to 403 handling in FolioAuth to work around transitory 403 errors was swallowing the content of the response (the missing permission) for actual 403 errors. Add a response.read() before raising the error.