### PR TITLE
Fix/auth flow transient recovery

### DIFF
--- a/docs/retry_configuration.md
+++ b/docs/retry_configuration.md
@@ -12,9 +12,18 @@ The retry system automatically handles:
 - **Exponential backoff** to avoid overwhelming servers
 - **Configurable limits** to prevent infinite retry loops
 
+There are two independent layers, and it is worth knowing which one you are configuring:
+
+1. **The authentication flow** (`FolioAuth`) always makes one automatic retry attempt on a
+   401 or a 403. This is not opt-in, and it applies to every request.
+2. **The retry decorators** (tenacity) add further attempts with exponential backoff on top
+   of that. These are opt-in via the environment variables below.
+
 ## Quick Start
 
-By default, **no retries are performed** - you must opt-in by setting environment variables:
+The decorator-based retries perform **no additional attempts by default** - you must opt-in
+by setting environment variables. (The single authentication-flow retry described above
+happens regardless.)
 
 ```bash
 # Enable basic server error retries
@@ -68,6 +77,47 @@ Configure retry behavior for authorization errors (403):
 | `FOLIOCLIENT_AUTH_ERROR_MAX_WAIT` | `60.0` | Maximum wait time between retries |
 
 **Note**: Auth errors include automatic re-authentication before retry attempts.
+
+### Authentication Flow Retries
+
+These apply to the single retry that `FolioAuth` performs inside the authentication flow,
+before the decorator-based retries above are involved.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `FOLIOCLIENT_FORBIDDEN_RETRY_DELAY` | `1.0` | Seconds to wait before replaying a request that returned 403 |
+
+#### Why a 403 is retried at all
+
+FOLIO's Keycloak integration currently translates every backend error that is not a 200,
+401 or 403 into a **403**. In practice this means a 403 is frequently a *masked transient
+failure* - a timeout, a 502/503, a dropped connection - rather than a genuine permission
+denial. The authentication flow therefore replays a 403 once.
+
+Because the condition has rarely cleared by the time an immediate replay reaches the
+server, the retry waits briefly first. The delay is deliberately short: a real permission
+denial cannot be distinguished from a masked transient today, so it pays the same cost.
+
+```bash
+# Wait longer, for environments with slower-recovering transient failures
+export FOLIOCLIENT_FORBIDDEN_RETRY_DELAY=3.0
+
+# Replay immediately, with no wait
+export FOLIOCLIENT_FORBIDDEN_RETRY_DELAY=0
+```
+
+Set it to `0` if your deployment returns 403 only for genuine permission denials, since
+in that case the wait is pure overhead. Once FOLIO passes real status codes through rather
+than collapsing them into 403, `0` becomes the better default.
+
+For heavier recovery, combine this with `FOLIOCLIENT_MAX_AUTH_ERROR_RETRIES`, which adds
+further attempts with exponential backoff *and* a fresh login between them.
+
+:::{note}
+A 401 is always followed by re-authentication and one retry, with no delay, because a 401
+is an authoritative statement that the token was rejected rather than a possibly-masked
+transient. There is no delay setting for it.
+:::
 
 ### Legacy Variables
 
@@ -274,6 +324,13 @@ The `handle_remote_protocol_error`, `use_client_session`, and `use_client_sessio
 **Issue**: Too many retries
 - **Solution**: Reduce `FOLIOCLIENT_MAX_*_ERROR_RETRIES`
 - **Solution**: Check for systemic issues causing repeated failures
+
+**Issue**: Requests that end in a 403 take about a second longer than expected
+- **Cause**: The authentication flow waits `FOLIOCLIENT_FORBIDDEN_RETRY_DELAY` (default
+  `1.0s`) before replaying a 403, because FOLIO frequently reports masked transient
+  failures as 403
+- **Solution**: If your deployment returns 403 only for genuine permission denials, set
+  `FOLIOCLIENT_FORBIDDEN_RETRY_DELAY=0`
 
 ### Debugging
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "folioclient"
-version = "1.0.11"
+version = "1.0.12"
 description = "An API wrapper over the FOLIO LSP API Suite (Formerly OKAPI)."
 authors = [
     { name = "Theodor Tolstoy", email = "github.teddes@tolstoy.se" },

--- a/src/folioclient/FolioClient.py
+++ b/src/folioclient/FolioClient.py
@@ -1306,7 +1306,10 @@ class FolioClient:
             FolioClientClosed: If the client has been closed.
         """
         self.validate_client_open()
-        with self.folio_auth._lock:
+        # Must use the async lock, not folio_auth._lock: a threading.RLock held across
+        # this await gives no mutual exclusion between coroutines (it is reentrant on
+        # the loop's own thread) and can let an older token overwrite a newer one.
+        async with self.folio_auth._get_async_lock():
             self.folio_auth._token = await self.folio_auth._do_async_auth()
 
     def logout(self) -> None:

--- a/src/folioclient/_httpx.py
+++ b/src/folioclient/_httpx.py
@@ -165,11 +165,8 @@ class FolioAuth(httpx.Auth):
         self, request: httpx.Request
     ) -> "Generator[httpx.Request, httpx.Response, None]":
         """Synchronous authentication flow for httpx.Client"""
-        with self._lock:
-            if not self._token or self._token_is_expiring():
-                self._token = self._do_sync_auth()
-
-        self._set_auth_cookies_on_request(request)
+        token_used = self._ensure_sync_token()
+        self._set_auth_cookies_on_request(request, token_used)
 
         # Set tenant header if not already present (allows per-request override)
         if "x-okapi-tenant" not in request.headers:
@@ -178,15 +175,10 @@ class FolioAuth(httpx.Auth):
         response = yield request
 
         if response.status_code == HTTPStatus.UNAUTHORIZED:
-            logger.debug("Received 401 Unauthorized, refreshing token")
             with self._lock:
-                if self._token and not self._token_is_expiring():
-                    # Another thread refreshed the token while we were waiting for the lock
-                    pass
-                else:
-                    self._token = self._do_sync_auth()
+                token_used = self._reauthenticate_sync(token_used)
 
-            self._set_auth_cookies_on_request(request)
+            self._set_auth_cookies_on_request(request, token_used)
             retry_response = yield request
 
             # If still unauthorized after fresh auth, something is seriously wrong
@@ -212,11 +204,8 @@ class FolioAuth(httpx.Auth):
         self, request: httpx.Request
     ) -> "AsyncGenerator[httpx.Request, httpx.Response]":
         """Asynchronous authentication flow for httpx.AsyncClient"""
-        async with self._get_async_lock():
-            if not self._token or self._token_is_expiring():
-                self._token = await self._do_async_auth()
-
-        self._set_auth_cookies_on_request(request)
+        token_used = await self._ensure_async_token()
+        self._set_auth_cookies_on_request(request, token_used)
 
         # Set tenant header if not already present (allows per-request override)
         if "x-okapi-tenant" not in request.headers:
@@ -225,15 +214,10 @@ class FolioAuth(httpx.Auth):
         response = yield request
 
         if response.status_code == HTTPStatus.UNAUTHORIZED:
-            logger.debug("Received 401 Unauthorized, refreshing token")
             async with self._get_async_lock():
-                if self._token and not self._token_is_expiring():
-                    # Another coroutine refreshed the token while we awaited the lock
-                    pass
-                else:
-                    self._token = await self._do_async_auth()
+                token_used = await self._reauthenticate_async(token_used)
 
-            self._set_auth_cookies_on_request(request)
+            self._set_auth_cookies_on_request(request, token_used)
             retry_response = yield request
 
             # If still unauthorized after fresh auth, something is seriously wrong
@@ -342,8 +326,20 @@ class FolioAuth(httpx.Auth):
             parsed = parsed.replace(tzinfo=timezone.utc)
         return parsed
 
-    def _set_auth_cookies_on_request(self, request: httpx.Request) -> None:
-        """Set authentication cookies on request, overriding any existing FOLIO auth cookies"""
+    def _set_auth_cookies_on_request(
+        self, request: httpx.Request, token: Optional[_Token] = None
+    ) -> None:
+        """Set authentication cookies on request, overriding any existing FOLIO auth cookies
+
+        Args:
+            request: The request to set cookies on.
+            token: The token whose cookies to apply. The auth flows pass the exact token
+                they validated, so that a concurrent refresh on another thread or loop
+                cannot substitute a different one between the check and this call.
+                Defaults to the current token.
+        """
+        if token is None:
+            token = self._token
         existing_cookie_header = request.headers.get("Cookie", "")
 
         # Parse existing cookies and filter out FOLIO auth cookies
@@ -351,8 +347,8 @@ class FolioAuth(httpx.Auth):
 
         # Add our authentication cookies
         auth_cookies = {}
-        if self._token and self._token.cookies:
-            for name, value in self._token.cookies.items():
+        if token and token.cookies:
+            for name, value in token.cookies.items():
                 auth_cookies[name] = value
 
         # Combine all cookies
@@ -379,25 +375,85 @@ class FolioAuth(httpx.Auth):
         return existing_cookies
 
     def _token_is_expiring(self) -> bool:
-        """Returns true if token is within 60 seconds of expiration"""
+        """Returns true if token is within 60 seconds of expiration.
+
+        This is a proactive optimization only: it saves a wasted round trip when the
+        token has already aged out, which is the common case in long-running jobs.
+
+        It is deliberately NOT the test used to decide whether to refresh after a 401.
+        The server rejecting a token is authoritative, and a token can be rejected
+        while still looking valid here -- clock skew, Keycloak key rotation, session
+        revocation, or a module with a stale JWKS cache. See _reauthenticate_sync.
+        """
         return (
             not self._token
             or not self._token.expires_at
             or (datetime.now(tz=timezone.utc) + timedelta(seconds=60)) >= self._token.expires_at
         )
 
+    def _require_token(self) -> _Token:
+        """Return the current token, failing loudly if there somehow is none."""
+        if not self._token:  # pragma: no cover - auth returns a token or raises
+            raise ValueError("Authentication failed: No token available.")
+        return self._token
+
+    def _ensure_sync_token(self) -> _Token:
+        """Return the token to use, authenticating first if it is expiring."""
+        with self._lock:
+            if self._token_is_expiring():
+                self._token = self._do_sync_auth()
+            return self._require_token()
+
+    async def _ensure_async_token(self) -> _Token:
+        """Return the token to use, authenticating first if it is expiring."""
+        async with self._get_async_lock():
+            if self._token_is_expiring():
+                self._token = await self._do_async_auth()
+            return self._require_token()
+
+    def _reauthenticate_sync(self, token_used: _Token) -> _Token:
+        """Re-authenticate after a 401 unless another caller already replaced our token.
+
+        Caller must hold self._lock.
+
+        A 401 means the server rejected the token we actually sent, so we always
+        refresh -- expiry is not a sufficient test (see _token_is_expiring). The one
+        exception is that another thread may have replaced the token while our request
+        was in flight, in which case retrying with the newer token is enough and a
+        second login would be wasted. Comparing identity rather than expiry gives us
+        that de-duplication without ever suppressing a genuinely needed refresh.
+        """
+        if self._token is token_used:
+            logger.debug("Received 401 Unauthorized, re-authenticating")
+            self._token = self._do_sync_auth()
+        else:
+            logger.debug(
+                "Received 401 Unauthorized; token was already replaced concurrently,"
+                " retrying with the newer token"
+            )
+        return self._require_token()
+
+    async def _reauthenticate_async(self, token_used: _Token) -> _Token:
+        """Re-authenticate after a 401 unless another caller already replaced our token.
+
+        Caller must hold the loop's async lock. See _reauthenticate_sync for rationale.
+        """
+        if self._token is token_used:
+            logger.debug("Received 401 Unauthorized, re-authenticating")
+            self._token = await self._do_async_auth()
+        else:
+            logger.debug(
+                "Received 401 Unauthorized; token was already replaced concurrently,"
+                " retrying with the newer token"
+            )
+        return self._require_token()
+
     @property
     def folio_auth_token(self):
         """Property that returns a currently valid FOLIO auth token"""
-        with self._lock:
-            if not self._token or self._token_is_expiring():
-                self._token = self._do_sync_auth()
-            return self._token.auth_token
+        return self._ensure_sync_token().auth_token
 
     @property
     def folio_refresh_token(self):
         """Property that returns the currently valid FOLIO refresh token"""
-        with self._lock:
-            if not self._token or self._token_is_expiring():
-                self._token = self._do_sync_auth()
-            return self._token.refresh_token
+        return self._ensure_sync_token().refresh_token

--- a/src/folioclient/_httpx.py
+++ b/src/folioclient/_httpx.py
@@ -86,6 +86,21 @@ class FolioAuth(httpx.Auth):
         # across network I/O (see sync_auth_flow and FolioClient.login), which is fine
         # for worker threads but means it must never be awaited on by an event loop.
         # That is why _get_async_lock does not use it. See _get_async_lock.
+        #
+        # WHY RLock WHEN NOTHING NESTS? Nothing does, and nothing should: every holder
+        # calls only _do_sync_auth, which builds a bare httpx.Client with no auth
+        # attached and so cannot re-enter this flow, and every `yield request` sits
+        # outside the locked region so no caller-supplied code (event hooks, custom
+        # transports) runs while it is held. The reentrancy is purely a safety net.
+        # Because the lock spans network I/O with a possibly unlimited timeout, an
+        # accidental nested acquire under a plain threading.Lock would hang the user's
+        # process outright; under RLock it degrades to a redundant login instead.
+        #
+        # That net must not become cover for real nesting, so the invariant is enforced
+        # in tests rather than by the primitive: see
+        # test_sync_lock_is_never_acquired_reentrantly. If you add code inside a locked
+        # region, do not let it touch folio_auth_token / access_token -- those acquire
+        # this lock, and that test will fail.
         self._lock: threading.RLock = threading.RLock()
 
         # One asyncio.Lock per event loop, keyed weakly so that entries disappear when

--- a/src/folioclient/_httpx.py
+++ b/src/folioclient/_httpx.py
@@ -106,6 +106,8 @@ class FolioAuth(httpx.Auth):
 
             # If still unauthorized after fresh auth, something is seriously wrong
             if retry_response.status_code == HTTPStatus.UNAUTHORIZED:
+                # Ensure response body is available to callers inspecting exception.response.text
+                retry_response.read()
                 raise httpx.HTTPStatusError(
                     "Authentication failed after token refresh."
                     " Check credentials and authorization.",
@@ -113,7 +115,7 @@ class FolioAuth(httpx.Auth):
                     response=retry_response,
                 )
 
-        if response.status_code == HTTPStatus.FORBIDDEN:
+        elif response.status_code == HTTPStatus.FORBIDDEN:
             logger.debug("Received unexpected 403 Forbidden. Will retry request once.")
             retry_response = yield request
             if retry_response.status_code == HTTPStatus.FORBIDDEN:
@@ -151,6 +153,8 @@ class FolioAuth(httpx.Auth):
 
             # If still unauthorized after fresh auth, something is seriously wrong
             if retry_response.status_code == HTTPStatus.UNAUTHORIZED:
+                # Ensure response body is available to callers inspecting exception.response.text
+                await retry_response.aread()
                 raise httpx.HTTPStatusError(
                     "Authentication failed after token refresh."
                     " Check credentials and authorization.",
@@ -158,7 +162,7 @@ class FolioAuth(httpx.Auth):
                     response=retry_response,
                 )
 
-        if response.status_code == HTTPStatus.FORBIDDEN:
+        elif response.status_code == HTTPStatus.FORBIDDEN:
             logger.debug("Received unexpected 403 Forbidden. Will retry request once.")
             retry_response = yield request
             if retry_response.status_code == HTTPStatus.FORBIDDEN:

--- a/src/folioclient/_httpx.py
+++ b/src/folioclient/_httpx.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import asyncio
 from datetime import datetime, timedelta, timezone
 import logging
 import threading
+import weakref
 import httpx
 
 from dataclasses import dataclass
@@ -60,8 +62,91 @@ class FolioAuth(httpx.Auth):
             "Content-Type": "application/json",
             "Accept": "application/json",
         }
-        self._token: FolioAuth._Token = self._do_sync_auth()
+
+        # Serializes the *synchronous* paths. NOTE: this lock is deliberately held
+        # across network I/O (see sync_auth_flow and FolioClient.login), which is fine
+        # for worker threads but means it must never be awaited on by an event loop.
+        # That is why _get_async_lock does not use it. See _get_async_lock.
         self._lock: threading.RLock = threading.RLock()
+
+        # One asyncio.Lock per event loop, keyed weakly so that entries disappear when
+        # a loop is garbage collected (a long-lived client used across many
+        # asyncio.run() calls must not accumulate locks). See _get_async_lock.
+        self._async_locks: "weakref.WeakKeyDictionary[asyncio.AbstractEventLoop, asyncio.Lock]" = (
+            weakref.WeakKeyDictionary()
+        )
+        # Guards _async_locks only. Separate from _lock on purpose: this one is held
+        # for a dictionary lookup and nothing else, so acquiring it from the event
+        # loop thread cannot stall the loop.
+        self._async_locks_guard: threading.Lock = threading.Lock()
+
+        # Locks must exist before the first authentication: _do_sync_auth does not take
+        # them, but the token properties it feeds do.
+        self._token: FolioAuth._Token = self._do_sync_auth()
+
+    def _get_async_lock(self) -> asyncio.Lock:
+        """Return the asyncio.Lock for the currently running event loop.
+
+        Must be called from inside a coroutine; asyncio.get_running_loop() raises
+        RuntimeError otherwise.
+
+        WHY NOT JUST USE self._lock (threading.RLock)?
+            An RLock is reentrant *per thread*. All coroutines on one event loop share
+            a thread, so when coroutine A holds it across an `await`, coroutine B
+            acquires it too -- reentrantly, immediately, successfully. It provides zero
+            mutual exclusion between coroutines: 10 concurrent flows produced 10
+            logins in testing.
+
+        WHY NOT A PLAIN threading.Lock?
+            That does exclude, by blocking the calling *thread*. On an event loop that
+            thread is the loop, so it can never resume the coroutine holding the lock:
+            a hard deadlock. Verified -- it hangs. No threading primitive is usable
+            here; the lock must suspend the coroutine, not the thread.
+
+        WHY ONE LOCK PER LOOP RATHER THAN ONE CACHED LOCK?
+            asyncio.Lock binds itself to a loop the first time it actually has to wait
+            (see _LoopBoundMixin._get_loop) and then raises "is bound to a different
+            event loop" if reused elsewhere. Crucially it binds only on the *contended*
+            path -- an uncontended acquire returns before _get_loop() is reached -- so a
+            single cached lock passes every light test and then fails once real
+            concurrency arrives.
+
+            The binding is also permanent, which makes even strictly *sequential* reuse
+            fail. One cached lock breaks when a single client is reused across two
+            asyncio.run() calls: verified to raise "is bound to a different event loop"
+            on the second run. That is easy to reach by accident -- a script calling
+            asyncio.run() twice, a module- or session-scoped client fixture under
+            pytest-asyncio (which builds a fresh loop per test), or a re-run notebook
+            cell -- and it surfaces only under contention, i.e. in production rather
+            than in tests. test_async_lock_survives_sequential_event_loops covers it.
+
+            Rebuilding one cached lock on loop change fixes that but is worse overall:
+            with two live loops they replace each other's lock continuously (measured:
+            39 rebuilds and 16 distinct lock objects per loop), destroying exclusion
+            *within* each loop as well as between them. Keying by loop costs about two
+            more lines than either and is correct for both cases.
+
+            Note that N separate FolioAuth instances across N loops is always fine --
+            each owns its own lock. The constraint only ever applied to sharing one
+            instance, and keying by loop removes it.
+
+        RESIDUAL GAP, ACCEPTED DELIBERATELY:
+            The sync path uses _lock and each loop uses its own asyncio.Lock, so these
+            are mutually unaware. Two event loops, or one loop plus sync worker
+            threads, can therefore each perform one login concurrently. That is
+            bounded and benign: assigning self._token is a single attribute store, so
+            no reader ever observes a torn value, and the worst outcome is a redundant
+            login or discarding a marginally newer token. Closing the gap would mean
+            holding a cross-thread lock across an `await`, i.e. reintroducing the
+            deadlock above.
+        """
+        loop = asyncio.get_running_loop()
+        with self._async_locks_guard:
+            lock = self._async_locks.get(loop)
+            if lock is None:
+                lock = asyncio.Lock()
+                self._async_locks[loop] = lock
+            return lock
 
     @property
     def tenant_id(self) -> str:
@@ -127,7 +212,7 @@ class FolioAuth(httpx.Auth):
         self, request: httpx.Request
     ) -> "AsyncGenerator[httpx.Request, httpx.Response]":
         """Asynchronous authentication flow for httpx.AsyncClient"""
-        with self._lock:
+        async with self._get_async_lock():
             if not self._token or self._token_is_expiring():
                 self._token = await self._do_async_auth()
 
@@ -141,9 +226,9 @@ class FolioAuth(httpx.Auth):
 
         if response.status_code == HTTPStatus.UNAUTHORIZED:
             logger.debug("Received 401 Unauthorized, refreshing token")
-            with self._lock:
+            async with self._get_async_lock():
                 if self._token and not self._token_is_expiring():
-                    # Another thread refreshed the token while we were waiting for the lock
+                    # Another coroutine refreshed the token while we awaited the lock
                     pass
                 else:
                     self._token = await self._do_async_auth()
@@ -249,8 +334,7 @@ class FolioAuth(httpx.Auth):
             parsed = isoparse(value)
         except (ValueError, OverflowError, TypeError):
             logger.warning(
-                "Could not parse token expiration %r; proactive refresh disabled for"
-                " this token.",
+                "Could not parse token expiration %r; proactive refresh disabled for this token.",
                 value,
             )
             return None

--- a/src/folioclient/_httpx.py
+++ b/src/folioclient/_httpx.py
@@ -6,6 +6,7 @@ import threading
 import httpx
 
 from dataclasses import dataclass
+from dateutil.parser import isoparse
 from http import HTTPStatus
 from typing import TYPE_CHECKING, NamedTuple, Optional
 
@@ -179,29 +180,7 @@ class FolioAuth(httpx.Auth):
             logger.debug("Authenticating synchronously with URL: %s", auth_url)
             response = client.post(auth_url, json=auth_data, headers=headers)
             response.raise_for_status()
-
-            token = response.cookies.get("folioAccessToken")
-            refresh_token = response.cookies.get("folioRefreshToken")
-            if not token:
-                raise ValueError("Authentication failed: No token received.")
-
-            expires_at = None
-            if "accessTokenExpiration" in response.json():
-                expires_at = datetime.fromisoformat(response.json()["accessTokenExpiration"])
-
-            refresh_token_expires_at = None
-            if "refreshTokenExpiration" in response.json():
-                refresh_token_expires_at = datetime.fromisoformat(
-                    response.json()["refreshTokenExpiration"]
-                )
-
-            return FolioAuth._Token(
-                auth_token=token,
-                refresh_token=refresh_token,
-                expires_at=expires_at,
-                refresh_token_expires_at=refresh_token_expires_at,
-                cookies=response.cookies,
-            )
+            return self._token_from_response(response)
 
     async def _do_async_auth(self) -> _Token:
         """Asynchronous authentication with the FOLIO system."""
@@ -219,29 +198,61 @@ class FolioAuth(httpx.Auth):
             logger.debug("Authenticating asynchronously with URL: %s", auth_url)
             response = await client.post(auth_url, json=auth_data, headers=headers)
             response.raise_for_status()
+            return self._token_from_response(response)
 
-            token = response.cookies.get("folioAccessToken")
-            refresh_token = response.cookies.get("folioRefreshToken")
-            if not token:
-                raise ValueError("Authentication failed: No token received.")
+    @classmethod
+    def _token_from_response(cls, response: httpx.Response) -> _Token:
+        """Build a _Token from an /authn/login-with-expiry response.
 
-            expires_at = None
-            if "accessTokenExpiration" in response.json():
-                expires_at = datetime.fromisoformat(response.json()["accessTokenExpiration"])
+        Shared by the sync and async auth methods so that the response parsing --
+        including the expiration handling in _parse_expiration -- exists in exactly
+        one place.
+        """
+        token = response.cookies.get("folioAccessToken")
+        if not token:
+            raise ValueError("Authentication failed: No token received.")
 
-            refresh_token_expires_at = None
-            if "refreshTokenExpiration" in response.json():
-                refresh_token_expires_at = datetime.fromisoformat(
-                    response.json()["refreshTokenExpiration"]
-                )
+        payload = response.json()
+        return cls._Token(
+            auth_token=token,
+            refresh_token=response.cookies.get("folioRefreshToken"),
+            expires_at=cls._parse_expiration(payload.get("accessTokenExpiration")),
+            refresh_token_expires_at=cls._parse_expiration(payload.get("refreshTokenExpiration")),
+            cookies=response.cookies,
+        )
 
-            return FolioAuth._Token(
-                auth_token=token,
-                refresh_token=refresh_token,
-                expires_at=expires_at,
-                refresh_token_expires_at=refresh_token_expires_at,
-                cookies=response.cookies,
+    @staticmethod
+    def _parse_expiration(value: Optional[str]) -> Optional[datetime]:
+        """Parse a FOLIO token expiration timestamp into an aware UTC datetime.
+
+        CARE POINT: this must not use datetime.fromisoformat. FOLIO emits ISO-8601 with
+        a trailing 'Z' (verified against live Okapi and Eureka instances, e.g.
+        '2026-08-07T18:13:36Z'), and fromisoformat cannot parse a 'Z' suffix before
+        Python 3.11. Since this package supports 3.10, fromisoformat raised ValueError
+        during authentication and made the client unusable there entirely. isoparse
+        handles 'Z' and offsets written without a colon on every supported version.
+
+        A value with no UTC offset is coerced to UTC so that comparisons in
+        _token_is_expiring never mix naive and aware datetimes (which would raise
+        TypeError on every request).
+
+        An unparseable value degrades to None rather than raising: losing the proactive
+        expiry check is far better than failing authentication outright.
+        """
+        if not value:
+            return None
+        try:
+            parsed = isoparse(value)
+        except (ValueError, OverflowError, TypeError):
+            logger.warning(
+                "Could not parse token expiration %r; proactive refresh disabled for"
+                " this token.",
+                value,
             )
+            return None
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return parsed
 
     def _set_auth_cookies_on_request(self, request: httpx.Request) -> None:
         """Set authentication cookies on request, overriding any existing FOLIO auth cookies"""

--- a/src/folioclient/_httpx.py
+++ b/src/folioclient/_httpx.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 import asyncio
 from datetime import datetime, timedelta, timezone
 import logging
+import os
 import threading
+import time
 import weakref
 import httpx
 
@@ -11,6 +13,13 @@ from dataclasses import dataclass
 from dateutil.parser import isoparse
 from http import HTTPStatus
 from typing import TYPE_CHECKING, NamedTuple, Optional
+
+try:  # pragma: no cover - depends on the installed httpx internals
+    from httpx._multipart import MultipartStream as _MultipartStream
+except ImportError:  # pragma: no cover
+    # If httpx moves this, _request_is_replayable degrades to treating multipart as
+    # non-replayable, which costs a retry rather than corrupting a request body.
+    _MultipartStream = None
 
 if TYPE_CHECKING:  # pragma: no cover
     from collections.abc import AsyncGenerator, Generator
@@ -47,6 +56,16 @@ class FolioAuth(httpx.Auth):
     This class supports both Okapi and Eureka-based FOLIO systems.
     Works with both synchronous and asynchronous httpx clients.
     """
+
+    _UNREPLAYABLE_401_MESSAGE = (
+        "Refreshed the token after a 401, but this request's body is a consumed stream"
+        " and cannot be replayed; returning the 401 to the caller. Later requests will"
+        " use the new token."
+    )
+    _UNREPLAYABLE_403_MESSAGE = (
+        "Received 403 Forbidden, but this request's body is a consumed stream and cannot"
+        " be replayed; returning the 403 to the caller."
+    )
 
     class _Token(NamedTuple):
         auth_token: Optional[str]
@@ -175,8 +194,16 @@ class FolioAuth(httpx.Auth):
         response = yield request
 
         if response.status_code == HTTPStatus.UNAUTHORIZED:
+            # Refresh before considering the retry. The server rejected this token, and
+            # that is true whether or not we can replay this particular request, so
+            # returning early without refreshing would leave every later request using
+            # a token we already know is rejected.
             with self._lock:
                 token_used = self._reauthenticate_sync(token_used)
+
+            if not self._request_is_replayable(request):
+                logger.warning(self._UNREPLAYABLE_401_MESSAGE)
+                return
 
             self._set_auth_cookies_on_request(request, token_used)
             retry_response = yield request
@@ -193,7 +220,13 @@ class FolioAuth(httpx.Auth):
                 )
 
         elif response.status_code == HTTPStatus.FORBIDDEN:
-            logger.debug("Received unexpected 403 Forbidden. Will retry request once.")
+            if not self._request_is_replayable(request):
+                logger.warning(self._UNREPLAYABLE_403_MESSAGE)
+                return
+            delay = self._forbidden_retry_delay()
+            logger.debug("Received unexpected 403 Forbidden. Retrying once after %.3gs.", delay)
+            if delay:
+                time.sleep(delay)
             retry_response = yield request
             if retry_response.status_code == HTTPStatus.FORBIDDEN:
                 # Ensure response body is available to callers inspecting exception.response.text
@@ -214,8 +247,13 @@ class FolioAuth(httpx.Auth):
         response = yield request
 
         if response.status_code == HTTPStatus.UNAUTHORIZED:
+            # Refresh before considering the retry -- see sync_auth_flow for why.
             async with self._get_async_lock():
                 token_used = await self._reauthenticate_async(token_used)
+
+            if not self._request_is_replayable(request):
+                logger.warning(self._UNREPLAYABLE_401_MESSAGE)
+                return
 
             self._set_auth_cookies_on_request(request, token_used)
             retry_response = yield request
@@ -232,7 +270,13 @@ class FolioAuth(httpx.Auth):
                 )
 
         elif response.status_code == HTTPStatus.FORBIDDEN:
-            logger.debug("Received unexpected 403 Forbidden. Will retry request once.")
+            if not self._request_is_replayable(request):
+                logger.warning(self._UNREPLAYABLE_403_MESSAGE)
+                return
+            delay = self._forbidden_retry_delay()
+            logger.debug("Received unexpected 403 Forbidden. Retrying once after %.3gs.", delay)
+            if delay:
+                await asyncio.sleep(delay)
             retry_response = yield request
             if retry_response.status_code == HTTPStatus.FORBIDDEN:
                 # Ensure response body is available to callers inspecting exception.response.text
@@ -390,6 +434,62 @@ class FolioAuth(httpx.Auth):
             or not self._token.expires_at
             or (datetime.now(tz=timezone.utc) + timedelta(seconds=60)) >= self._token.expires_at
         )
+
+    @staticmethod
+    def _request_is_replayable(request: httpx.Request) -> bool:
+        """Return True if this request's body can safely be sent a second time.
+
+        Retrying means yielding the same httpx.Request again, which re-iterates
+        request.stream. Whether that is safe depends on which stream httpx chose:
+
+        - bytes / json / form data -> ByteStream, and httpx sets request._content.
+          The body lives in memory, so re-iteration replays it. Safe.
+        - multipart (files=) -> MultipartStream, and _content is NOT set. It is still
+          replayable, because FileField.render_data seeks each file back to 0 on every
+          render; two sends produce byte-identical bodies. Testing `_content` alone
+          therefore misclassifies every file upload as non-replayable and silently
+          drops its retry -- which matters most for uploads, where a masked transient
+          403 is exactly what we want to recover from.
+        - a generator or file object -> IteratorByteStream, consumed by the first send.
+          Generators raise StreamConsumed on replay (loud). File objects are worse:
+          .read() at EOF yields b"", so the retry silently becomes a zero-length
+          POST/PUT that the caller believes carried a full body.
+
+        CARE POINT: this is written as an allowlist on purpose. If an httpx internal
+        changes and we get it wrong, the failure is "we skip a retry we could have
+        done" (harmless) rather than "we send a truncated body" (data loss). Do not
+        invert it into a denylist on IteratorByteStream for brevity.
+        """
+        if hasattr(request, "_content"):
+            return True
+        return _MultipartStream is not None and isinstance(request.stream, _MultipartStream)
+
+    @staticmethod
+    def _forbidden_retry_delay() -> float:
+        """Seconds to wait before replaying a request that came back 403.
+
+        WHY WAIT AT ALL? FOLIO's Keycloak integration currently translates every
+        backend error that is not a 200/401/403 into a 403, so in practice a 403 is
+        frequently a *masked transient* failure -- a timeout, a 502/503, a reset
+        connection -- rather than a real permission denial. An immediate replay is
+        poorly matched to that: the condition has rarely cleared microseconds later.
+
+        WHY KEEP IT SHORT? A genuine permission denial cannot be distinguished from a
+        masked transient today, so it pays this delay too. Heavier recovery belongs to
+        folio_retry_on_auth_error, which already retries 403 with exponential backoff
+        and a fresh login (though it is off by default -- see
+        FOLIOCLIENT_MAX_AUTH_ERROR_RETRIES).
+
+        Tunable via FOLIOCLIENT_FORBIDDEN_RETRY_DELAY; set it to 0 to restore the
+        previous immediate-replay behavior. Once FOLIO passes real status codes
+        through, 0 becomes the better default and this can be retired.
+        """
+        raw = os.environ.get("FOLIOCLIENT_FORBIDDEN_RETRY_DELAY", "1.0")
+        try:
+            return max(0.0, float(raw))
+        except ValueError:
+            logger.warning("Invalid FOLIOCLIENT_FORBIDDEN_RETRY_DELAY %r; using 1.0 seconds.", raw)
+            return 1.0
 
     def _require_token(self) -> _Token:
         """Return the current token, failing loudly if there somehow is none."""

--- a/tests/test_httpx.py
+++ b/tests/test_httpx.py
@@ -1004,3 +1004,236 @@ def test_event_loop_not_stalled_while_sync_login_holds_lock(monkeypatch):
         elapsed = asyncio.run(main())
         assert released.is_set()
         assert elapsed < 0.2, f"_get_async_lock blocked for {elapsed:.3f}s on the sync lock"
+
+
+# --- 403 retry: replayability and delay ------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _no_forbidden_retry_delay(monkeypatch):
+    """Neutralize the 403 retry delay for the whole module so tests stay fast.
+
+    Tests that care about the delay set the variable themselves. The default value is
+    asserted separately in test_forbidden_retry_delay_default, so this fixture cannot
+    hide a change to it.
+    """
+    monkeypatch.setenv("FOLIOCLIENT_FORBIDDEN_RETRY_DELAY", "0")
+
+
+def test_forbidden_retry_delay_default(monkeypatch):
+    monkeypatch.delenv("FOLIOCLIENT_FORBIDDEN_RETRY_DELAY", raising=False)
+    assert FolioAuth._forbidden_retry_delay() == 1.0
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [("0", 0.0), ("0.25", 0.25), ("2.5", 2.5), ("-5", 0.0), ("bogus", 1.0), ("", 1.0)],
+)
+def test_forbidden_retry_delay_from_env(monkeypatch, raw, expected):
+    monkeypatch.setenv("FOLIOCLIENT_FORBIDDEN_RETRY_DELAY", raw)
+    assert FolioAuth._forbidden_retry_delay() == expected
+
+
+def test_403_retry_waits_before_replaying(monkeypatch):
+    """A masked transient 403 needs time to clear; an instant replay is unlikely to help."""
+    import time
+
+    monkeypatch.setenv("FOLIOCLIENT_FORBIDDEN_RETRY_DELAY", "0.2")
+    params = make_params()
+    resp = DummyResponse(cookies={"folioAccessToken": "t", "folioRefreshToken": "r"})
+
+    with httpx_client_patcher(lambda *a, **k: DummyClient(resp)):
+        fa = FolioAuth(params)
+        gen = fa.sync_auth_flow(httpx.Request("GET", "https//folio/x"))
+        next(gen)
+        start = time.perf_counter()
+        gen.send(DummyResponse(status_code=403))  # triggers the delayed retry
+        elapsed = time.perf_counter() - start
+        assert elapsed >= 0.2, f"retry replayed after only {elapsed:.3f}s"
+
+
+@pytest.mark.asyncio
+async def test_async_403_retry_waits_before_replaying(monkeypatch):
+    import time
+
+    monkeypatch.setenv("FOLIOCLIENT_FORBIDDEN_RETRY_DELAY", "0.2")
+    params = make_params()
+    resp = DummyResponse(cookies={"folioAccessToken": "t", "folioRefreshToken": "r"})
+
+    def fake_client(*a, **k):
+        return DummyClient(resp)
+
+    def fake_async_client(*a, **k):
+        return DummyAsyncClient(resp)
+
+    with httpx_client_patcher(fake_client, fake_async_client):
+        fa = FolioAuth(params)
+        agen = fa.async_auth_flow(httpx.Request("GET", "https//folio/x"))
+        await agen.__anext__()
+        start = time.perf_counter()
+        await agen.asend(DummyResponse(status_code=403))
+        elapsed = time.perf_counter() - start
+        assert elapsed >= 0.2
+
+
+def test_403_retry_delay_of_zero_does_not_sleep(monkeypatch):
+    """Setting the delay to 0 must restore immediate-replay behavior."""
+    import time
+
+    monkeypatch.setenv("FOLIOCLIENT_FORBIDDEN_RETRY_DELAY", "0")
+    params = make_params()
+    resp = DummyResponse(cookies={"folioAccessToken": "t", "folioRefreshToken": "r"})
+
+    with httpx_client_patcher(lambda *a, **k: DummyClient(resp)):
+        fa = FolioAuth(params)
+        gen = fa.sync_auth_flow(httpx.Request("GET", "https//folio/x"))
+        next(gen)
+        start = time.perf_counter()
+        gen.send(DummyResponse(status_code=403))
+        assert time.perf_counter() - start < 0.1
+
+
+# --- Request replayability -------------------------------------------------------
+
+
+def _generator_body():
+    yield b'{"record": "important"}'
+
+
+def test_in_memory_bodies_are_replayable():
+    assert FolioAuth._request_is_replayable(httpx.Request("GET", "https//folio/x"))
+    assert FolioAuth._request_is_replayable(
+        httpx.Request("POST", "https//folio/x", json={"a": 1})
+    )
+    assert FolioAuth._request_is_replayable(
+        httpx.Request("POST", "https//folio/x", content=b"raw-bytes")
+    )
+    assert FolioAuth._request_is_replayable(
+        httpx.Request("POST", "https//folio/x", data={"a": "1"})
+    )
+
+
+def test_multipart_is_replayable(tmp_path):
+    """files= produces a MultipartStream with no _content, but it IS replayable.
+
+    httpx seeks each file field back to 0 on every render, so testing _content alone
+    would wrongly drop the retry for every file upload.
+    """
+    f = tmp_path / "record.mrc"
+    f.write_bytes(b"RECORD-DATA")
+    req = httpx.Request("POST", "https//folio/x", files={"file": f.open("rb")})
+    assert not hasattr(req, "_content"), "precondition: multipart is not materialized"
+    assert FolioAuth._request_is_replayable(req)
+
+
+def test_multipart_bodies_really_do_replay_identically(tmp_path):
+    """Verify the assumption behind the multipart allowlist entry."""
+    f = tmp_path / "record.mrc"
+    f.write_bytes(b"RECORD-DATA")
+    req = httpx.Request("POST", "https//folio/x", files={"file": f.open("rb")})
+    first = b"".join(req.stream)
+    second = b"".join(req.stream)
+    assert first == second and b"RECORD-DATA" in first
+
+
+@pytest.mark.parametrize("body_kind", ["generator", "filehandle"])
+def test_streaming_bodies_are_not_replayable(tmp_path, body_kind):
+    if body_kind == "generator":
+        body = _generator_body()
+    else:
+        f = tmp_path / "record.mrc"
+        f.write_bytes(b"RECORD-DATA")
+        body = f.open("rb")
+    req = httpx.Request("POST", "https//folio/x", content=body)
+    assert not FolioAuth._request_is_replayable(req)
+
+
+def test_multipart_403_is_retried(tmp_path):
+    """End-to-end: a file upload must still get its 403 retry."""
+    f = tmp_path / "record.mrc"
+    f.write_bytes(b"RECORD-DATA")
+    params = make_params()
+    resp = DummyResponse(cookies={"folioAccessToken": "t", "folioRefreshToken": "r"})
+
+    with httpx_client_patcher(lambda *a, **k: DummyClient(resp)):
+        fa = FolioAuth(params)
+        req = httpx.Request("POST", "https//folio/x", files={"file": f.open("rb")})
+        gen = fa.sync_auth_flow(req)
+        next(gen)
+        retried = gen.send(DummyResponse(status_code=403))
+        assert retried is req, "multipart uploads must be retried on 403"
+
+
+def test_streaming_403_is_not_retried(tmp_path):
+    """A consumed stream must surface the 403 rather than a silently-emptied retry."""
+    params = make_params()
+    resp = DummyResponse(cookies={"folioAccessToken": "t", "folioRefreshToken": "r"})
+
+    with httpx_client_patcher(lambda *a, **k: DummyClient(resp)):
+        fa = FolioAuth(params)
+        req = httpx.Request("POST", "https//folio/x", content=_generator_body())
+        gen = fa.sync_auth_flow(req)
+        next(gen)
+        with pytest.raises(StopIteration):
+            gen.send(DummyResponse(status_code=403))
+
+
+def test_streaming_401_still_refreshes_the_token(tmp_path):
+    """We cannot retry a consumed stream, but the rejected token must still be replaced.
+
+    Otherwise every later request keeps using a token the server has rejected -- and
+    with an unknown expiry the client would never recover on its own.
+    """
+    params = make_params()
+    resp = DummyResponse(
+        cookies={"folioAccessToken": "stale", "folioRefreshToken": "r"},
+        json_data={
+            "accessTokenExpiration": (
+                datetime.now(tz=timezone.utc) + timedelta(hours=1)
+            ).isoformat()
+        },
+    )
+
+    with httpx_client_patcher(lambda *a, **k: DummyClient(resp)):
+        fa = FolioAuth(params)
+        assert fa._token.auth_token == "stale"
+        fa._do_sync_auth = lambda: make_token("refreshed")
+        req = httpx.Request("POST", "https//folio/x", content=_generator_body())
+        gen = fa.sync_auth_flow(req)
+        next(gen)
+        with pytest.raises(StopIteration):
+            gen.send(DummyResponse(status_code=401))
+        assert fa._token.auth_token == "refreshed", "token must be refreshed for later requests"
+
+
+@pytest.mark.asyncio
+async def test_async_streaming_401_still_refreshes_the_token():
+    params = make_params()
+    resp = DummyResponse(
+        cookies={"folioAccessToken": "stale", "folioRefreshToken": "r"},
+        json_data={
+            "accessTokenExpiration": (
+                datetime.now(tz=timezone.utc) + timedelta(hours=1)
+            ).isoformat()
+        },
+    )
+
+    def fake_client(*a, **k):
+        return DummyClient(resp)
+
+    def fake_async_client(*a, **k):
+        return DummyAsyncClient(resp)
+
+    with httpx_client_patcher(fake_client, fake_async_client):
+        fa = FolioAuth(params)
+
+        async def refreshed():
+            return make_token("refreshed")
+
+        fa._do_async_auth = refreshed
+        req = httpx.Request("POST", "https//folio/x", content=_generator_body())
+        agen = fa.async_auth_flow(req)
+        await agen.__anext__()
+        with pytest.raises(StopAsyncIteration):
+            await agen.asend(DummyResponse(status_code=401))
+        assert fa._token.auth_token == "refreshed"

--- a/tests/test_httpx.py
+++ b/tests/test_httpx.py
@@ -525,3 +525,50 @@ async def test_async_auth_flow_403_retry_still_forbidden(monkeypatch):
         # Retry also returns 403 — should raise
         with pytest.raises(httpx.HTTPStatusError):
             await agen.asend(DummyResponse(status_code=403))
+
+
+# --- Token expiration parsing ---------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "2030-01-01T12:00:00.000Z",  # FOLIO's real format; fromisoformat < 3.11 rejects 'Z'
+        "2030-01-01T12:00:00Z",
+        "2030-01-01T12:00:00+00:00",
+        "2030-01-01T12:00:00+0000",  # offset written without a colon
+    ],
+)
+def test_parse_expiration_accepts_folio_formats(value):
+    """Every form FOLIO is known to emit must parse, and must come back tz-aware."""
+    parsed = FolioAuth._parse_expiration(value)
+    assert parsed is not None
+    assert parsed.tzinfo is not None, "naive result would make _token_is_expiring raise TypeError"
+
+
+def test_parse_expiration_coerces_naive_to_utc():
+    parsed = FolioAuth._parse_expiration("2030-01-01T12:00:00")
+    assert parsed is not None and parsed.utcoffset() == timedelta(0)
+
+
+@pytest.mark.parametrize("value", [None, "", "not-a-timestamp", "2030-13-45T99:99:99Z"])
+def test_parse_expiration_returns_none_for_unusable_values(value):
+    """Unparseable expirations must not raise -- that would break authentication."""
+    assert FolioAuth._parse_expiration(value) is None
+
+
+def test_expiring_check_tolerates_real_folio_timestamp(monkeypatch):
+    """End-to-end: a real FOLIO 'Z' timestamp parses and compares without raising."""
+    params = make_params()
+    resp = DummyResponse(
+        cookies={"folioAccessToken": "t", "folioRefreshToken": "r"},
+        json_data={
+            "accessTokenExpiration": "2030-01-01T12:00:00.000Z",
+            "refreshTokenExpiration": "2030-01-02T12:00:00.000Z",
+        },
+    )
+    with httpx_client_patcher(lambda *a, **k: DummyClient(resp)):
+        fa = FolioAuth(params)
+        assert fa._token.expires_at is not None
+        assert fa._token.refresh_token_expires_at is not None
+        assert fa._token_is_expiring() is False  # would raise TypeError if naive

--- a/tests/test_httpx.py
+++ b/tests/test_httpx.py
@@ -324,9 +324,12 @@ def test_folio_auth_token_refreshes_when_expired(monkeypatch):
         assert fa.folio_auth_token == "old"
 
 
-def test_sync_auth_flow_pass_branch_no_refresh(monkeypatch):
+def test_sync_401_skips_reauth_when_token_replaced_concurrently(monkeypatch):
+    """A 401 must NOT re-authenticate if another caller already replaced our token.
+
+    De-duplication is by token identity, so retrying with the newer token is enough.
+    """
     params = make_params()
-    # initial auth response with future expiration
     now = datetime.now(tz=timezone.utc)
     resp = DummyResponse(cookies={"folioAccessToken": "init", "folioRefreshToken": "init-r"}, json_data={"accessTokenExpiration": (now + timedelta(hours=1)).isoformat()})
 
@@ -335,18 +338,88 @@ def test_sync_auth_flow_pass_branch_no_refresh(monkeypatch):
 
     with httpx_client_patcher(fake_client):
         fa = FolioAuth(params)
-        fa._do_sync_auth = lambda: (_ for _ in ()).throw(RuntimeError("should not refresh"))
         req = httpx.Request("GET", "https//folio/resource")
         gen = fa.sync_auth_flow(req)
         next(gen)
+        # Simulate another thread refreshing while our request was in flight
+        fa._token = make_token("newer")
+        fa._do_sync_auth = lambda: (_ for _ in ()).throw(RuntimeError("should not refresh"))
         yielded = gen.send(DummyResponse(status_code=401))
         assert yielded is req
         with pytest.raises(StopIteration):
             gen.send(DummyResponse(status_code=200))
 
 
+def test_sync_401_reauths_even_when_token_looks_valid(monkeypatch):
+    """A 401 is authoritative: refresh even when the token is nowhere near expiry.
+
+    Covers revocation, Keycloak key rotation and clock skew, where the local expiry
+    check cannot tell that the server has stopped accepting the token.
+    """
+    params = make_params()
+    now = datetime.now(tz=timezone.utc)
+    resp = DummyResponse(cookies={"folioAccessToken": "init", "folioRefreshToken": "init-r"}, json_data={"accessTokenExpiration": (now + timedelta(hours=1)).isoformat()})
+
+    def fake_client(*args, **kwargs):
+        return DummyClient(resp)
+
+    with httpx_client_patcher(fake_client):
+        fa = FolioAuth(params)
+        assert fa._token_is_expiring() is False  # looks perfectly good locally
+        calls = []
+
+        def refreshed():
+            calls.append(1)
+            return make_token("refreshed")
+
+        fa._do_sync_auth = refreshed
+        req = httpx.Request("GET", "https//folio/resource")
+        gen = fa.sync_auth_flow(req)
+        next(gen)
+        yielded = gen.send(DummyResponse(status_code=401))
+        assert yielded is req
+        assert calls == [1], "expected exactly one re-authentication"
+        assert fa._token.auth_token == "refreshed"
+        with pytest.raises(StopIteration):
+            gen.send(DummyResponse(status_code=200))
+
+
+def test_sync_401_retry_carries_the_new_token_cookies(monkeypatch):
+    """The retry must actually be sent with the refreshed cookies, not the stale ones."""
+    params = make_params()
+    # Future expiry, so the proactive check does not refresh before the first request.
+    resp = DummyResponse(
+        cookies={"folioAccessToken": "stale", "folioRefreshToken": "stale-r"},
+        json_data={
+            "accessTokenExpiration": (
+                datetime.now(tz=timezone.utc) + timedelta(hours=1)
+            ).isoformat()
+        },
+    )
+
+    with httpx_client_patcher(lambda *a, **k: DummyClient(resp)):
+        fa = FolioAuth(params)
+        fresh = httpx.Cookies()
+        fresh.set("folioAccessToken", "fresh-token")
+        fa._do_sync_auth = lambda: FolioAuth._Token(
+            auth_token="fresh-token",
+            refresh_token="fresh-r",
+            expires_at=datetime.now(tz=timezone.utc) + timedelta(hours=1),
+            refresh_token_expires_at=None,
+            cookies=fresh,
+        )
+        req = httpx.Request("GET", "https//folio/resource")
+        gen = fa.sync_auth_flow(req)
+        next(gen)
+        assert "stale" in req.headers["Cookie"]
+        gen.send(DummyResponse(status_code=401))
+        assert "fresh-token" in req.headers["Cookie"]
+        assert "stale" not in req.headers["Cookie"]
+
+
 @pytest.mark.asyncio
-async def test_async_auth_flow_pass_branch_no_refresh(monkeypatch):
+async def test_async_401_skips_reauth_when_token_replaced_concurrently(monkeypatch):
+    """Async: a 401 must NOT re-authenticate if the token was already replaced."""
     params = make_params()
     now = datetime.now(tz=timezone.utc)
     resp = DummyResponse(cookies={"folioAccessToken": "i2", "folioRefreshToken": "r2"}, json_data={"accessTokenExpiration": (now + timedelta(hours=1)).isoformat()})
@@ -358,17 +431,96 @@ async def test_async_auth_flow_pass_branch_no_refresh(monkeypatch):
 
     with httpx_client_patcher(fake_client, fake_async_client):
         fa = FolioAuth(params)
-        async def should_not_call():
-            raise RuntimeError("should not be called")
-        fa._do_async_auth = should_not_call
         req = httpx.Request("GET", "https//folio/asyncpass")
         agen = fa.async_auth_flow(req)
         first = await agen.__anext__()
         assert first is req
+        fa._token = make_token("newer")
+
+        async def should_not_call():
+            raise RuntimeError("should not be called")
+
+        fa._do_async_auth = should_not_call
         second = await agen.asend(DummyResponse(status_code=401))
         assert second is req
         with pytest.raises(StopAsyncIteration):
             await agen.asend(DummyResponse(status_code=200))
+
+
+@pytest.mark.asyncio
+async def test_async_401_reauths_even_when_token_looks_valid(monkeypatch):
+    """Async: a 401 re-authenticates even when the token is nowhere near expiry."""
+    params = make_params()
+    now = datetime.now(tz=timezone.utc)
+    resp = DummyResponse(cookies={"folioAccessToken": "i2", "folioRefreshToken": "r2"}, json_data={"accessTokenExpiration": (now + timedelta(hours=1)).isoformat()})
+
+    def fake_client(*args, **kwargs):
+        return DummyClient(resp)
+    def fake_async_client(*args, **kwargs):
+        return DummyAsyncClient(resp)
+
+    with httpx_client_patcher(fake_client, fake_async_client):
+        fa = FolioAuth(params)
+        assert fa._token_is_expiring() is False
+        calls = []
+
+        async def refreshed():
+            calls.append(1)
+            return make_token("refreshed")
+
+        fa._do_async_auth = refreshed
+        req = httpx.Request("GET", "https//folio/asyncpass")
+        agen = fa.async_auth_flow(req)
+        await agen.__anext__()
+        second = await agen.asend(DummyResponse(status_code=401))
+        assert second is req
+        assert calls == [1], "expected exactly one re-authentication"
+        with pytest.raises(StopAsyncIteration):
+            await agen.asend(DummyResponse(status_code=200))
+
+
+def test_concurrent_threads_401_trigger_one_reauth(monkeypatch):
+    """N sync threads all seeing a 401 on the same token must produce one login.
+
+    The first thread to take the lock refreshes; the rest see a different token
+    identity and retry with it instead of logging in again.
+    """
+    import threading
+    import time
+
+    params = make_params()
+    resp = DummyResponse(cookies={"folioAccessToken": "shared", "folioRefreshToken": "r"})
+
+    with httpx_client_patcher(lambda *a, **k: DummyClient(resp)):
+        fa = FolioAuth(params)
+        calls = []
+        calls_guard = threading.Lock()
+
+        def slow_login():
+            with calls_guard:
+                calls.append(1)
+            time.sleep(0.05)  # the network round trip
+            return make_token(f"tok{len(calls)}")
+
+        started = threading.Barrier(8)
+
+        def one_request():
+            gen = fa.sync_auth_flow(httpx.Request("GET", "https//folio/x"))
+            next(gen)
+            started.wait()  # all threads hold the same token before any sees a 401
+            fa._do_sync_auth = slow_login
+            try:
+                gen.send(DummyResponse(status_code=401))
+                gen.send(DummyResponse(status_code=200))
+            except StopIteration:
+                pass
+
+        threads = [threading.Thread(target=one_request) for _ in range(8)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        assert len(calls) == 1, f"expected 1 login for 8 threads on one token, got {len(calls)}"
 
 
 @pytest.mark.asyncio

--- a/tests/test_httpx.py
+++ b/tests/test_httpx.py
@@ -1237,3 +1237,84 @@ async def test_async_streaming_401_still_refreshes_the_token():
         with pytest.raises(StopAsyncIteration):
             await agen.asend(DummyResponse(status_code=401))
         assert fa._token.auth_token == "refreshed"
+
+
+# --- Sync lock reentrancy --------------------------------------------------------
+
+
+class ReentrancyDetectingLock:
+    """RLock wrapper that raises if one thread acquires it while already holding it.
+
+    FolioAuth._lock is an RLock so that unexpected nesting degrades to a redundant
+    login rather than hanging a caller's process on a lock held across network I/O.
+    That safety net must not silently excuse real nesting, so we assert here what
+    RLock permits at runtime.
+    """
+
+    def __init__(self):
+        import threading
+
+        self._real = threading.RLock()
+        self._state = threading.local()
+        self.acquisitions = 0
+
+    def __enter__(self):
+        depth = getattr(self._state, "depth", 0)
+        if depth:
+            raise AssertionError(f"_lock acquired reentrantly (depth {depth + 1})")
+        self._state.depth = depth + 1
+        self.acquisitions += 1
+        return self._real.__enter__()
+
+    def __exit__(self, *exc):
+        self._state.depth -= 1
+        return self._real.__exit__(*exc)
+
+
+def test_reentrancy_detector_actually_detects():
+    """Guard the guard: a detector that never fires would make the test below vacuous."""
+    lock = ReentrancyDetectingLock()
+    with lock:
+        with pytest.raises(AssertionError, match="reentrantly"):
+            with lock:
+                pass
+
+
+def test_sync_lock_is_never_acquired_reentrantly(monkeypatch):
+    """No sync path may acquire _lock while already holding it.
+
+    Covers the proactive refresh, the token properties, the 401 re-authentication and
+    the 403 retry. If a future change puts an access_token / folio_auth_token read
+    inside a locked region, this fails instead of deadlocking a user in production.
+    """
+    params = make_params()
+    resp = DummyResponse(cookies={"folioAccessToken": "t", "folioRefreshToken": "r"})
+
+    with httpx_client_patcher(lambda *a, **k: DummyClient(resp)):
+        fa = FolioAuth(params)
+        detector = ReentrancyDetectingLock()
+        fa._lock = detector
+
+        # Proactive refresh via _ensure_sync_token, plus both token properties.
+        fa._token = None
+        assert fa.folio_auth_token == "t"
+        assert fa.folio_refresh_token == "r"
+
+        # Proactive refresh inside sync_auth_flow, then the 401 re-authentication.
+        fa._token = make_token("current", expires_in=-timedelta(minutes=5))
+        gen = fa.sync_auth_flow(httpx.Request("GET", "https//folio/x"))
+        next(gen)
+        gen.send(DummyResponse(status_code=401))
+        with pytest.raises(StopIteration):
+            gen.send(DummyResponse(status_code=200))
+
+        # The 403 retry path (does not lock, but must not start doing so reentrantly).
+        gen2 = fa.sync_auth_flow(httpx.Request("GET", "https//folio/x"))
+        next(gen2)
+        gen2.send(DummyResponse(status_code=403))
+        with pytest.raises(StopIteration):
+            gen2.send(DummyResponse(status_code=200))
+
+        assert detector.acquisitions >= 3, (
+            f"expected the locked paths to be exercised, saw {detector.acquisitions}"
+        )

--- a/tests/test_httpx.py
+++ b/tests/test_httpx.py
@@ -572,3 +572,79 @@ def test_expiring_check_tolerates_real_folio_timestamp(monkeypatch):
         assert fa._token.expires_at is not None
         assert fa._token.refresh_token_expires_at is not None
         assert fa._token_is_expiring() is False  # would raise TypeError if naive
+
+
+class ReadTrackingResponse(DummyResponse):
+    """DummyResponse that records whether the body was read before being raised.
+
+    httpx hands the auth flow an *unread* response and only calls response.read()
+    if the flow yields again; on an exception it calls response.close(). So the flow
+    must read the body itself before raising, or callers inspecting
+    exception.response.text get ResponseNotRead.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.read_called = False
+
+    def read(self):
+        self.read_called = True
+        return super().read()
+
+    async def aread(self):
+        self.read_called = True
+        return await super().aread()
+
+
+def test_401_retry_body_is_read_before_raising(monkeypatch):
+    """exception.response.text must be usable after auth fails post-refresh."""
+    params = make_params()
+    auth_resp = DummyResponse(cookies={"folioAccessToken": "t", "folioRefreshToken": "r"})
+
+    with httpx_client_patcher(lambda *a, **k: DummyClient(auth_resp)):
+        fa = FolioAuth(params)
+        gen = fa.sync_auth_flow(httpx.Request("GET", "https//folio/x"))
+        next(gen)
+        gen.send(DummyResponse(status_code=401))
+        final = ReadTrackingResponse(status_code=401)
+        with pytest.raises(httpx.HTTPStatusError):
+            gen.send(final)
+        assert final.read_called, "body must be read before raising, or .text is unavailable"
+
+
+@pytest.mark.asyncio
+async def test_async_401_retry_body_is_read_before_raising(monkeypatch):
+    params = make_params()
+    auth_resp = DummyResponse(cookies={"folioAccessToken": "t", "folioRefreshToken": "r"})
+
+    def fake_client(*args, **kwargs):
+        return DummyClient(auth_resp)
+
+    def fake_async_client(*args, **kwargs):
+        return DummyAsyncClient(auth_resp)
+
+    with httpx_client_patcher(fake_client, fake_async_client):
+        fa = FolioAuth(params)
+        agen = fa.async_auth_flow(httpx.Request("GET", "https//folio/x"))
+        await agen.__anext__()
+        await agen.asend(DummyResponse(status_code=401))
+        final = ReadTrackingResponse(status_code=401)
+        with pytest.raises(httpx.HTTPStatusError):
+            await agen.asend(final)
+        assert final.read_called
+
+
+def test_403_retry_body_is_read_before_raising(monkeypatch):
+    """Parity check: the 403 path already did this (b579e7b); keep it covered."""
+    params = make_params()
+    auth_resp = DummyResponse(cookies={"folioAccessToken": "t", "folioRefreshToken": "r"})
+
+    with httpx_client_patcher(lambda *a, **k: DummyClient(auth_resp)):
+        fa = FolioAuth(params)
+        gen = fa.sync_auth_flow(httpx.Request("GET", "https//folio/x"))
+        next(gen)
+        gen.send(DummyResponse(status_code=403))
+        final = ReadTrackingResponse(status_code=403)
+        with pytest.raises(httpx.HTTPStatusError):
+            gen.send(final)
+        assert final.read_called

--- a/tests/test_httpx.py
+++ b/tests/test_httpx.py
@@ -648,3 +648,207 @@ def test_403_retry_body_is_read_before_raising(monkeypatch):
         with pytest.raises(httpx.HTTPStatusError):
             gen.send(final)
         assert final.read_called
+
+
+def make_token(auth_token="tok", expires_in=timedelta(hours=1)):
+    """Build a _Token that is not near expiry."""
+    return FolioAuth._Token(
+        auth_token=auth_token,
+        refresh_token=f"{auth_token}-r",
+        expires_at=datetime.now(tz=timezone.utc) + expires_in,
+        refresh_token_expires_at=None,
+        cookies=None,
+    )
+
+
+# --- Async lock registry ---------------------------------------------------------
+# These cover the parts of _get_async_lock that are easy to break by accident.
+
+
+@pytest.mark.asyncio
+async def test_concurrent_async_flows_authenticate_once(monkeypatch):
+    """The core guarantee: concurrent coroutines share one login.
+
+    A threading.RLock cannot do this -- it is reentrant on the event loop's thread,
+    so every coroutine acquires it and they all authenticate.
+    """
+    import asyncio
+
+    params = make_params()
+    resp = DummyResponse(cookies={"folioAccessToken": "t", "folioRefreshToken": "r"})
+
+    with httpx_client_patcher(
+        lambda *a, **k: DummyClient(resp), lambda *a, **k: DummyAsyncClient(resp)
+    ):
+        fa = FolioAuth(params)
+        fa._token = None  # force every flow to want a token
+        calls = []
+
+        async def slow_auth():
+            calls.append(1)
+            await asyncio.sleep(0.01)  # the network round trip
+            return make_token("shared")
+
+        fa._do_async_auth = slow_auth
+
+        async def one_request():
+            agen = fa.async_auth_flow(httpx.Request("GET", "https//folio/x"))
+            await agen.__anext__()
+            with pytest.raises(StopAsyncIteration):
+                await agen.asend(DummyResponse(status_code=200))
+
+        await asyncio.gather(*(one_request() for _ in range(10)))
+        assert calls == [1], f"expected 1 login for 10 concurrent flows, got {len(calls)}"
+
+
+@pytest.mark.asyncio
+async def test_async_lock_is_stable_within_one_loop(monkeypatch):
+    """Repeated calls on the same loop must return the identical lock object.
+
+    If this returns a fresh lock each time, mutual exclusion silently disappears.
+    """
+    params = make_params()
+    resp = DummyResponse(cookies={"folioAccessToken": "t"})
+    with httpx_client_patcher(lambda *a, **k: DummyClient(resp)):
+        fa = FolioAuth(params)
+        first = fa._get_async_lock()
+        assert all(fa._get_async_lock() is first for _ in range(5))
+
+
+def test_concurrent_event_loops_each_keep_their_own_lock(monkeypatch):
+    """Two live loops in two threads must not clobber each other's lock.
+
+    A single cached lock rebuilt on loop change thrashes here: each loop replaces the
+    other's lock, so coroutines within one loop end up holding different objects.
+    """
+    import asyncio
+    import threading
+
+    params = make_params()
+    resp = DummyResponse(cookies={"folioAccessToken": "t"})
+    with httpx_client_patcher(lambda *a, **k: DummyClient(resp)):
+        fa = FolioAuth(params)
+        seen = {}
+        seen_guard = threading.Lock()
+
+        async def worker(tag):
+            for _ in range(20):
+                obj = fa._get_async_lock()
+                with seen_guard:
+                    seen.setdefault(tag, set()).add(id(obj))
+                await asyncio.sleep(0.001)
+
+        async def main(tag):
+            await asyncio.gather(worker(tag), worker(tag))
+
+        threads = [
+            threading.Thread(target=lambda t=tag: asyncio.run(main(t)))
+            for tag in ("loopA", "loopB")
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert set(seen) == {"loopA", "loopB"}
+        for tag, ids in seen.items():
+            assert len(ids) == 1, f"{tag} saw {len(ids)} lock objects; exclusion is broken"
+        assert seen["loopA"] != seen["loopB"], "different loops must not share a lock"
+
+
+def test_async_lock_survives_sequential_event_loops(monkeypatch):
+    """A client reused across asyncio.run() calls must work under contention.
+
+    A single cached asyncio.Lock raises "is bound to a different event loop" here --
+    but only once there is contention, which is why this test forces two waiters.
+    """
+    import asyncio
+
+    params = make_params()
+    resp = DummyResponse(cookies={"folioAccessToken": "t"})
+    with httpx_client_patcher(lambda *a, **k: DummyClient(resp)):
+        fa = FolioAuth(params)
+
+        async def contended():
+            async def hold():
+                async with fa._get_async_lock():
+                    await asyncio.sleep(0.01)
+
+            await asyncio.gather(hold(), hold())
+
+        asyncio.run(contended())
+        asyncio.run(contended())  # must not raise
+
+
+def test_async_lock_registry_does_not_leak(monkeypatch):
+    """Finished loops must drop out of the registry, or long-lived clients leak."""
+    import asyncio
+    import gc
+
+    params = make_params()
+    resp = DummyResponse(cookies={"folioAccessToken": "t"})
+    with httpx_client_patcher(lambda *a, **k: DummyClient(resp)):
+        fa = FolioAuth(params)
+
+        async def touch():
+            fa._get_async_lock()
+
+        for _ in range(5):
+            asyncio.run(touch())
+        gc.collect()
+        assert len(fa._async_locks) == 0, "WeakKeyDictionary should release dead loops"
+
+
+def test_get_async_lock_requires_a_running_loop(monkeypatch):
+    """Documented precondition: it is an async-only helper."""
+    params = make_params()
+    resp = DummyResponse(cookies={"folioAccessToken": "t"})
+    with httpx_client_patcher(lambda *a, **k: DummyClient(resp)):
+        fa = FolioAuth(params)
+        with pytest.raises(RuntimeError):
+            fa._get_async_lock()
+
+
+def test_async_lock_guard_is_not_the_sync_lock(monkeypatch):
+    """The registry guard must be distinct from _lock, which is held across network I/O.
+
+    If they were the same lock, a sync login in another thread would stall the whole
+    event loop for the duration of that login (unbounded when timeout is None).
+    """
+    params = make_params()
+    resp = DummyResponse(cookies={"folioAccessToken": "t"})
+    with httpx_client_patcher(lambda *a, **k: DummyClient(resp)):
+        fa = FolioAuth(params)
+        assert fa._async_locks_guard is not fa._lock
+
+
+def test_event_loop_not_stalled_while_sync_login_holds_lock(monkeypatch):
+    """A thread holding _lock across a slow login must not block the event loop."""
+    import asyncio
+    import threading
+    import time
+
+    params = make_params()
+    resp = DummyResponse(cookies={"folioAccessToken": "t"})
+    with httpx_client_patcher(lambda *a, **k: DummyClient(resp)):
+        fa = FolioAuth(params)
+        released = threading.Event()
+
+        def hog():
+            with fa._lock:  # mimics sync_auth_flow / FolioClient.login
+                time.sleep(0.4)  # a slow /authn/login-with-expiry
+            released.set()
+
+        async def main():
+            t = threading.Thread(target=hog)
+            t.start()
+            time.sleep(0.05)  # let the thread take _lock first
+            start = time.perf_counter()
+            fa._get_async_lock()  # must not wait on _lock
+            elapsed = time.perf_counter() - start
+            t.join()
+            return elapsed
+
+        elapsed = asyncio.run(main())
+        assert released.is_set()
+        assert elapsed < 0.2, f"_get_async_lock blocked for {elapsed:.3f}s on the sync lock"


### PR DESCRIPTION
## Description

Fixes a set of correctness bugs in `FolioAuth` and makes the retry paths actually
effective at recovering from the transient failures FOLIO produces in practice.

The headline item is that **folioclient cannot authenticate at all on Python 3.10**, a
version we claim to support: FOLIO returns `accessTokenExpiration` with a trailing `Z`
(verified against live Okapi and Eureka instances, e.g. `2026-08-07T18:13:36Z`), and
`datetime.fromisoformat` cannot parse that before 3.11, so `FolioAuth.__init__` raised
`ValueError`.

Focused commits, each independently reviewable:

| Commit | Change |
|---|---|
| `b519434` | Parse expirations with `dateutil.isoparse` — unbreaks Python 3.10 |
| `3f0aee6` | Read the 401 retry body before raising, so `exc.response.text` works |
| `b5bce6e` | Serialize async auth with a per-loop `asyncio.Lock` |
| `f3dd119` | Treat a 401 as authoritative when deciding to re-authenticate |
| `6bddc05` | Make 403 retries effective: replayability + a short delay |
| `9445702` | Enforce in tests that the sync lock is never acquired reentrantly |
| `43611bb` | Bump version to 1.0.12 |
| `a3bdf0c` | Document the authentication-flow 403 retry delay |


### Why each matters

**Async authentication was never serialized.** The async flow guarded its refresh with a
`threading.RLock`, which is reentrant *per thread*. Every coroutine on an event loop
shares one thread, so when one held it across an `await` the next re-acquired it
immediately — 10 concurrent flows produced 10 logins. Switching to a plain
`threading.Lock` is worse: it blocks the loop's own thread, which then cannot resume the
holder, deadlocking with no traceback. Now uses one `asyncio.Lock` per event loop, kept
in a `WeakKeyDictionary`. `FolioClient.async_login` had the same bug and is fixed too.

**A 401 was not treated as authoritative.** The handler refreshed only if
`_token_is_expiring()` agreed, but a token can be rejected while still looking locally
valid — clock skew, Keycloak key rotation, revocation, a module with a stale JWKS cache.
In all of those the old code replayed the identical request, got a second 401, and
raised. De-duplication is now by token *identity*, which keeps the "N callers, one login"
property without ever suppressing a needed refresh.

**403 retries were ineffective, and 403 is the transient channel.** FOLIO's Keycloak
integration currently collapses every backend error that is not a 200/401/403 into a 403,
so a 403 is frequently a masked timeout/502/503 rather than a real permission denial.
Two problems: multipart uploads silently lost their retry (httpx only sets
`request._content` for in-memory bodies, but `MultipartStream` *is* replayable because it
seeks each field back to 0), and the retry was immediate, which rarely outlasts a blip.
Now multipart is retried and there is a short configurable delay.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

No public API changes. Three behavior changes worth a reviewer's attention:

1. A 401 now triggers re-authentication in cases where it previously did not.
2. A 403 retry now waits `FOLIOCLIENT_FORBIDDEN_RETRY_DELAY` seconds (default `1.0`)
   before replaying. Set it to `0` to restore the previous immediate replay. A genuine
   permission denial pays this too, since the two are indistinguishable until FOLIO
   passes real status codes through.
3. Multipart (`files=`) requests are now retried on 401/403 where they previously were
   not.

## Testing

- [x] Unit tests pass — **271 passing**, up from 225 (+46 tests)
- [x] Integration tests pass (if applicable)
- [x] New tests added for new functionality

Integration matrix run against all seven server configs: `5 failed, 186 passed,
38 skipped, 24 errors`. Every failure and error is the `snapshot-2-eureka` config,
which has a single root cause — `httpx.ConnectError: [Errno 8] nodename nor servname
provided` — because `folio-etesting-snapshot2-kong.ci.folio.org` no longer resolves.
An identical run on `master` produces the identical set of failing test IDs, so nothing
here is a regression. `snapshot`, `snapshot2`, `eureka`, `eureka-ecs`, `bugfest` and
`bugfest-next` all pass, including the `folio_post`/`folio_put`/`folio_delete` user
lifecycle test.

`test_get_large_dataset_id_offset` was deselected: it ignores the `server_config`
fixture and hardcodes `BUGFEST_CONFIG`, so `--integration-server` cannot filter it, and
it pages 1.5M instances. Worth fixing separately.

**Every behavioral claim was mutation-tested.** For the three riskiest commits we
deliberately reintroduced each regression — RLock in the async flow, a single cached
lock with and without rebuild-on-loop-change, sharing the sync lock as the registry
guard, expiry-gated 401, unconditional 401 re-auth, `_content`-only replayability,
immediate 403 replay, replayability-checked-before-refresh, and a nested lock acquire —
and confirmed each fails the test written for it. Without that, the async and multipart
tests in particular would have passed against broken code.

## Checklist

- [x] Code follows the project's style guidelines (`ruff check` and `ruff format` clean)
- [x] Self-review of code completed
- [x] Code is commented, particularly in hard-to-understand areas
- [x] Corresponding changes to documentation have been made
- [x] Changes generate no new warnings

`docs/retry_configuration.md` gains an "Authentication Flow Retries" section covering the
one new environment variable, `FOLIOCLIENT_FORBIDDEN_RETRY_DELAY`, plus a troubleshooting
entry for the most likely surprise (403 responses taking about a second longer). The page
now also distinguishes the two retry layers, correcting an existing claim that no retries
happen by default — the authentication flow has always made one automatic 401/403 attempt
regardless of configuration, and only the decorator-based retries are opt-in. Verified
with a clean `sphinx-build`.

`docs/authentication.md` needed no change: it already stated that the flow re-authenticates
"whenever it receives a `401`", which is what `f3dd119` finally makes true. The code was
the thing out of step with the documentation, not the reverse.

No changelog entry was added because the project only records entries at minor/major
boundaries — there are no v1.0.1–v1.0.12 sections.

## Notes for reviewers

The most unusual code in this PR is `_get_async_lock`, so it carries a long docstring
explaining why each alternative was rejected. The short version: `asyncio.Lock` binds to
a loop the first time it actually has to *wait*, and that binding is permanent. Because
an uncontended acquire returns before the binding happens, a single cached lock passes
light testing and then fails under real concurrency — including on strictly sequential
reuse, e.g. one client across two `asyncio.run()` calls or a session-scoped fixture under
`pytest-asyncio`. Rebuilding one cached lock on loop change is worse still: two live
loops replace each other's lock continuously (measured: 39 rebuilds, 16 distinct lock
objects per loop), destroying exclusion within each loop as well as between them.

`self._lock` remains an `RLock` even though nothing nests, because it is held across
network I/O with a possibly unlimited timeout: an accidental nested acquire under a plain
`Lock` would hang the caller's process, whereas `RLock` degrades to a redundant login.
That safety net is prevented from hiding real nesting by
`test_sync_lock_is_never_acquired_reentrantly` rather than by the primitive.

`_request_is_replayable` imports `httpx._multipart.MultipartStream`, a private path,
wrapped in `try/except ImportError` that degrades to "not replayable". It is written as
an allowlist on purpose: if an httpx internal changes, the failure is a skipped retry
rather than a replayed generator or an exhausted file handle silently becoming a
zero-length POST/PUT.

### Known follow-ups, deliberately not in scope

- `folio_retry_on_auth_error` already retries 403 with a fresh login, but ships disabled
  (`FOLIOCLIENT_MAX_AUTH_ERROR_RETRIES=0`) and its `multiplier=10.0` / `exp_base=3.0`
  defaults would cost ~100s per permission denial if enabled. Given 403 is the transient
  channel, that combination deserves revisiting.
- The in-flow 403 retry replays blind while `auth_refresh_callback` re-logs in. One of
  those is wrong; worth resolving deliberately.
- `_token_is_expiring()` still treats an unknown expiry as expiring, so a parse failure
  means one login per request. Left alone because changing it introduces staleness for
  `access_token` / `folio_headers`, which have no 401 fallback.
- `_cleanup_folio_auth`'s `del self.folio_auth._token` yields `AttributeError` rather
  than `FolioClientClosed` after close.
- Sampling a genuine permission-403 with a low-privilege user would show whether masked
  and real 403s are distinguishable by body shape, which would let the retry be narrowed
  precisely instead of retrying all 403s.
